### PR TITLE
Removal of AUR mention due to the package being removed from the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,6 @@ flatpak remote-add --user --if-not-exists hero-persson https://hero-persson.gith
 flatpak install org.unmojang.FjordLauncher
 ```
 
-### Arch Linux
-
-Fjord Launcher Unlocked is [available](https://aur.archlinux.org/packages?O=0&K=fjordlauncherunlocked) from the AUR:
-
-```Shell
-paru -S fjordlauncherunlocked
-paru -S fjordlauncherunlocked-git # build latest Git commit from source
-```
-
 ### Nix
 
 This repository contains a Nix flake:


### PR DESCRIPTION
FjordLauncherUnlocked has been removed from the AUR, thus I removed the relevant part regarding the AUR install